### PR TITLE
Correct typo in dialog title for selected senators

### DIFF
--- a/src/app/senators/page.tsx
+++ b/src/app/senators/page.tsx
@@ -456,7 +456,7 @@ export default function Page() {
             if (!open) setSelectedSenatorsModalOpen(false);
           }}>
             <DialogContent  className="w-11/12">
-              <DialogTitle>You&aposve already got your 12</DialogTitle>
+              <DialogTitle>You&apos;ve already got your 12</DialogTitle>
               <DialogDescription>You previously selected the following:</DialogDescription>
               <ul className="full px-4">
                 {


### PR DESCRIPTION
This pull request includes a minor change to the `src/app/senators/page.tsx` file. The change corrects a typographical error in the `DialogTitle` component.

* [`src/app/senators/page.tsx`](diffhunk://#diff-1a90ec01e974852cc0b467f901e77d3e80a549343424f64e61796b68175f2f63L459-R459): Corrected the typographical error in the `DialogTitle` component from `You&aposve already got your 12` to `You&apos;ve already got your 12`.

Before:

![image](https://github.com/user-attachments/assets/f8dc6f16-ab69-49c2-be6d-155f3658ee39)


After:

![image](https://github.com/user-attachments/assets/e3c332c9-57a3-483b-b18d-7eb6f39ab3ef)
