### PR TITLE
Handle removal of local candidates and update related state

### DIFF
--- a/src/app/balota/page.tsx
+++ b/src/app/balota/page.tsx
@@ -89,6 +89,38 @@ export default function Page() {
     
     const removeLocalCandidate = async (id:string) => {
         setLocalCandidates(localCandidates.filter(lc => lc.id !== id));
+
+        const removedCandidate = localCandidates.find((lc) => lc.id === id);
+        if (removedCandidate) {
+            switch (removedCandidate.position) {
+            case "GOVERNOR":
+                setGovernor(undefined);
+                break;
+            case "VICE-GOVERNOR":
+                setViceGovernor(undefined);
+                break;
+            case "PROVINCIAL BOARD MEMBER":
+            case "PROVINCIAL_COUNCIL":
+                setProvincialBoardMembers(
+                    provincialBoardMembers.filter((pbm) => pbm.id !== id)
+                );
+                break;
+            case "MAYOR":
+                setMayor(undefined);
+                break;
+            case "VICE-MAYOR":
+                setViceMayor(undefined);
+                break;
+            case "COUNCILOR":
+                setCouncilors(councilors.filter((c) => c.id !== id));
+                break;
+            case "REPRESENTATIVE":
+            case "DISTRICT_REPRESENTATIVE":
+                setRepresentative(undefined);
+                break;
+            }
+        }
+
         await db.localCandidates.delete(id);
     }
 


### PR DESCRIPTION
This pull request includes an update to the `removeLocalCandidate` function in the `src/app/balota/page.tsx` file. The change resolves the issue of local candidates not being immediately removed from the display list when the trash icon is clicked.

Before:

![Alt Text](https://s4.ezgif.com/tmp/ezgif-4b00ce1dd0ca74.gif)

After:

![Alt Text](https://s4.ezgif.com/tmp/ezgif-43518244dd7e53.gif)
